### PR TITLE
Disabled redux persistence for the time being

### DIFF
--- a/Forward-client/app/root.tsx
+++ b/Forward-client/app/root.tsx
@@ -49,9 +49,9 @@ export function Layout({ children }: { children: React.ReactNode }) {
 }
 
 export default function App() {
-  store.subscribe(() => {
-    localStorage.setItem("reduxState", JSON.stringify(store.getState()));
-  });
+  // store.subscribe(() => {
+  //   localStorage.setItem("reduxState", JSON.stringify(store.getState()));
+  // });
   return (
     <Provider store={store}>
       <Outlet />

--- a/Forward-client/app/store.ts
+++ b/Forward-client/app/store.ts
@@ -24,10 +24,10 @@ const reducer = {
 export type RootState = StateFromReducersMapObject<typeof reducer>;
 
 // Only run if code is on client
-const preloadedState: RootState | undefined =
-  typeof window === "undefined"
-    ? undefined
-    : JSON.parse(localStorage.getItem("reduxState") || "null") || undefined;
+ const preloadedState: RootState | undefined = undefined;
+//   typeof window === "undefined"
+//     ? undefined
+//     : JSON.parse(localStorage.getItem("reduxState") || "null") || undefined;
 
 const store = configureStore({
   reducer,


### PR DESCRIPTION
As Andrew and I discussed, due to the nature of the users most likely not accessing the site from the same device every time, it is both a security risk and performance issue to mirror the user's state on the client AND the server. This PR removes that functionality for the time being.