### PR TITLE
About pages audio

### DIFF
--- a/Forward-client/app/routes/home.tsx
+++ b/Forward-client/app/routes/home.tsx
@@ -39,7 +39,7 @@ export default function Home() {
           </Link>
           <Link 
             prefetch="intent"
-            to={"/supportersOfYouth"}
+            to={"/youth"}
             className="bg-secondary/80 backdrop-blur-sm text-secondary-foreground px-8 py-4 rounded-full font-semibold text-lg transition-all duration-300 border border-secondary-border hover:border-muted-foreground shadow-sm hover:shadow-md">
             Learn More
           </Link>

--- a/Forward-client/app/routes/supportersOfYouth.tsx
+++ b/Forward-client/app/routes/supportersOfYouth.tsx
@@ -1,13 +1,17 @@
 import { Link } from "react-router";
+import MarkdownTTS from "@/components/ui/markdown-tts";
 
 export default function supportersOfYouth(){
     return (
         <div className="max-w-6xl mx-auto px-6 py-5">
             <h4 className="text-accent text-right">For supporters of youth</h4>
             
-            <div>
+            <MarkdownTTS controlsClassName="flex flex-row-reverse items-start justify-between gap-4">
                 <h1 className="text-4xl font-black text-accent mb-6">About Forward</h1>
+                {/* This adds a pause between reading the options. The opacity makes it invisible */}
+                <span className="text-[0px] opacity-0">.</span>
                 <h4 className="mb-6">Facilitating Opportunities for Reentry, Workforce, and Academic Readiness for Youth with Disabilities in Juvenile Justice</h4>
+                <span className="text-[0px] opacity-0">.</span>
                 
                 <p className="mb-8">FORWARD is a web-based transition curriculum designed to support youth with disabilities in juvenile justice and other alternative education settings as they prepare for life beyond high school. 
                     Whether you're a parent, caregiver, educator, mental health provider, probation officer, mentor, or other another type of youth supporter, your role in supporting young people during key transitions 
@@ -19,105 +23,120 @@ export default function supportersOfYouth(){
                     alt="Student looking thoughtfully into the distance" 
                     className="w-full max-w-2xl mx-auto rounded-lg my-6"
                 />
-            </div>
+            </MarkdownTTS>
 
             {/* paragraph two */}
             <div className="border-t border-muted pt-8">
-                <h3 className="text-2xl font-black mb-6">Why FORWARD?</h3>
+                <MarkdownTTS controlsClassName="flex flex-row-reverse items-start justify-between gap-4">
+                    <h3 className="text-2xl font-black mb-6">Why FORWARD?</h3>
+                    <span className="text-[0px] opacity-0">.</span>
 
-                <p className="mb-6">  FORWARD builds on several existing, research-informed transition curricula (e.g., INSITE, RISE, RAISE, Merging Two Worlds) 
-                    and was designed in response to persistent challenges observed in juvenile justice and alternative education settings. 
-                    These include limited instructional time, variability in youth participation, and difficulties delivering the most relevant content 
-                    before a young person exits a program.
-                </p>
+                    <p className="mb-6">  FORWARD builds on several existing, research-informed transition curricula (e.g., INSITE, RISE, RAISE, Merging Two Worlds) 
+                        and was designed in response to persistent challenges observed in juvenile justice and alternative education settings. 
+                        These include limited instructional time, variability in youth participation, and difficulties delivering the most relevant content 
+                        before a young person exits a program.
+                    </p>
 
-                <p className="mb-4">FORWARD addresses these issues by offering:</p>
+                    <p className="mb-4">FORWARD addresses these issues by offering:</p>
 
-                <div className="markdown mb-6">
-                    <ul>
-                        <li><b>Flexible, web-based content</b> that youth can access during and after placement</li>
-                        <li><b>Lessons that stand alone</b>, allowing youth to begin with whichever topic is most relevant to them</li>
-                        <li><b>Universal Design for Transition (UDT)</b> as a guiding framework to ensure cultural responsiveness, accessibility, and multiple means of engagement</li>
-                        <li><b>Accessibility features</b> including text-to-speech, closed captions, visual supports, speech-to-text responses, and simplified language at a 5th grade reading level</li>
-                    </ul>
-                </div>
-                
-                <img 
-                    src="/about_page/kids_huddled_up.jpg" 
-                    alt="Students huddled up" 
-                    className="w-full max-w-2xl mx-auto rounded-lg my-6"
-                />
+                    <div className="markdown mb-6">
+                        <ul>
+                            <li><b>Flexible, web-based content</b> that youth can access during and after placement</li>
+                            <li><b>Lessons that stand alone</b>, allowing youth to begin with whichever topic is most relevant to them</li>
+                            <li><b>Universal Design for Transition (UDT)</b> as a guiding framework to ensure cultural responsiveness, accessibility, and multiple means of engagement</li>
+                            <li><b>Accessibility features</b> including text-to-speech, closed captions, visual supports, speech-to-text responses, and simplified language at a 5th grade reading level</li>
+                        </ul>
+                    </div>
+                    
+                    <img 
+                        src="/about_page/kids_huddled_up.jpg" 
+                        alt="Students huddled up" 
+                        className="w-full max-w-2xl mx-auto rounded-lg my-6"
+                    />
+                </MarkdownTTS>
             </div>
 
             {/* section 3 */}
             <div className="border-t border-muted pt-8 mt-8">
-                <h3 className="text-2xl font-black mb-6">What Does FORWARD Teach?</h3>
-                
-                <p className="mb-4">FORWARD helps youth develop practical knowledge and skills across three key areas of transition:</p>
+                <MarkdownTTS controlsClassName="flex flex-row-reverse items-start justify-between gap-4">
+                    <h3 className="text-2xl font-black mb-6">What Does FORWARD Teach?</h3>
+                    <span className="text-[0px] opacity-0">.</span>
+                    
+                    <p className="mb-4">FORWARD helps youth develop practical knowledge and skills across three key areas of transition:</p>
 
-                <div className="markdown mb-6">
-                    <ul>
-                        <li>Academic Readiness - Preparing for postsecondary education, including college, trade school, or GED programs</li>
-                        <li>Workforce Readiness - Building job-seeking and workplace communication skills</li>
-                        <li>Independent Living Readiness - Managing responsibilities like budgeting, housing, and transportation</li>
-                    </ul>
-                </div>
+                    <div className="markdown mb-6">
+                        <ul>
+                            <li>Academic Readiness - Preparing for postsecondary education, including college, trade school, or GED programs</li>
+                            <li>Workforce Readiness - Building job-seeking and workplace communication skills</li>
+                            <li>Independent Living Readiness - Managing responsibilities like budgeting, housing, and transportation</li>
+                        </ul>
+                    </div>
 
-                <p className="mb-4">The curriculum includes five core lessons:</p>
+                    <p className="mb-4">The curriculum includes five core lessons:</p>
 
-                <div className="markdown mb-6">
-                    <ol>
-                        <li><b>Going to College</b></li>
-                        <li><b>Disclosure and Appropriate Communication</b></li>
-                        <li><b>Personal Finance Management</b></li>
-                        <li><b>Self-Advocacy</b></li>
-                        <li><b>Soft Skills Development</b></li>
-                    </ol>
-                </div>
+                    <div className="markdown mb-6">
+                        <ol>
+                            <li><b>Going to College</b></li>
+                            <li><b>Disclosure and Appropriate Communication</b></li>
+                            <li><b>Personal Finance Management</b></li>
+                            <li><b>Self-Advocacy</b></li>
+                            <li><b>Soft Skills Development</b></li>
+                        </ol>
+                    </div>
 
-                <p className="mb-8">
-                    Each lesson includes written content, videos, and interactive activities such as quizzes, 
-                    choose-your-path scenarios, simulations, and open-ended reflection. Lessons typically take 
-                    45–60 minutes to complete, though students are encouraged to move at their own pace and explore 
-                    deeply where they are most interested.Each lesson includes written content, videos, and interactive 
-                    activities such as quizzes, choose-your-path scenarios, simulations, and open-ended reflection. Lessons 
-                    typically take 45–60 minutes to complete, though students are encouraged to move at their own pace and 
-                    explore deeply where they are most interested.
-                </p>
+                    <p className="mb-8">
+                        Each lesson includes written content, videos, and interactive activities such as quizzes, 
+                        choose-your-path scenarios, simulations, and open-ended reflection. Lessons typically take 
+                        45–60 minutes to complete, though students are encouraged to move at their own pace and explore 
+                        deeply where they are most interested.Each lesson includes written content, videos, and interactive 
+                        activities such as quizzes, choose-your-path scenarios, simulations, and open-ended reflection. Lessons 
+                        typically take 45–60 minutes to complete, though students are encouraged to move at their own pace and 
+                        explore deeply where they are most interested.
+                    </p>
+                </MarkdownTTS>
             </div>
 
             <div className="mt-8">
-                <h3 className="text-2xl font-black mb-6">Designed for Flexibility and Choice</h3>
-                
-                <p className="mb-8">
-                    Many transition programs follow a set order of instruction, which can limit access to high-priority content 
-                    when youth are facing unpredictable timelines. FORWARD intentionally removes the requirement to move through 
-                    lessons sequentially. Youth can choose the topics that matter most to them and explore the rest as time allows. 
-                    This design increases relevance, reduces frustration, and centers youth autonomy — all while preserving the benefits 
-                    of identity development and self-reflection by embedding these themes across all lessons.
-                </p>
+                <MarkdownTTS controlsClassName="flex flex-row-reverse items-start justify-between gap-4">
+                    <h3 className="text-2xl font-black mb-6">Designed for Flexibility and Choice</h3>
+                    <span className="text-[0px] opacity-0">.</span>
+                    
+                    <p className="mb-8">
+                        Many transition programs follow a set order of instruction, which can limit access to high-priority content 
+                        when youth are facing unpredictable timelines. FORWARD intentionally removes the requirement to move through 
+                        lessons sequentially. Youth can choose the topics that matter most to them and explore the rest as time allows. 
+                        This design increases relevance, reduces frustration, and centers youth autonomy — all while preserving the benefits 
+                        of identity development and self-reflection by embedding these themes across all lessons.
+                    </p>
+                </MarkdownTTS>
             </div>
 
             <div className="mt-8">
-                <h3 className="text-2xl font-black mb-6">Who Is It For?</h3>
-                
-                <p className="mb-8">
-                    FORWARD was created for youth ages 14–21 with disabilities in juvenile justice or other alternative settings. However, 
-                    the content may also benefit any young person preparing for transition, particularly those with low literacy levels or limited access to consistent instruction.
-                    We encourage adults who support youth — including parents, foster parents, teachers, case managers, mentors, parole officers, and others — to explore the site, 
-                    become familiar with the lessons, and engage in conversations about what youth are learning. Your support and encouragement play a powerful role in helping young 
-                    people apply what they've learned to real-life decisions and opportunities.
-                </p>
+                <MarkdownTTS controlsClassName="flex flex-row-reverse items-start justify-between gap-4">
+                    <h3 className="text-2xl font-black mb-6">Who Is It For?</h3>
+                    <span className="text-[0px] opacity-0">.</span>
+                    
+                    <p className="mb-8">
+                        FORWARD was created for youth ages 14–21 with disabilities in juvenile justice or other alternative settings. However, 
+                        the content may also benefit any young person preparing for transition, particularly those with low literacy levels or limited access to consistent instruction.
+                        We encourage adults who support youth — including parents, foster parents, teachers, case managers, mentors, parole officers, and others — to explore the site, 
+                        become familiar with the lessons, and engage in conversations about what youth are learning. Your support and encouragement play a powerful role in helping young 
+                        people apply what they've learned to real-life decisions and opportunities.
+                    </p>
+                </MarkdownTTS>
             </div>
 
             <div className="mt-8">
-                <h3 className="text-2xl font-black mb-6">How can I help?</h3>
-                
-                <p>
-                    In addition to becoming familiar with the lessons and site, you can review the facilitator guides that accompany each lesson. 
-                    These are designed with your support in mind, offering specific activities, conversation starters, and other ideas for engaging 
-                    youth and making connections that will enhance their learning. Facilitator guides can be accessed here. 
-                </p>
+                <MarkdownTTS controlsClassName="flex flex-row-reverse items-start justify-between gap-4">
+                    <h3 className="text-2xl font-black mb-6">How can I help?</h3>
+                    <span className="text-[0px] opacity-0">.</span>
+                    
+                    <p>
+                        In addition to becoming familiar with the lessons and site, you can review the facilitator guides that accompany each lesson. 
+                        These are designed with your support in mind, offering specific activities, conversation starters, and other ideas for engaging 
+                        youth and making connections that will enhance their learning. Facilitator guides can be accessed here. 
+                    </p>
+                </MarkdownTTS>
             </div>
 
         <div className="text-right mt-8">

--- a/Forward-client/app/routes/youth.tsx
+++ b/Forward-client/app/routes/youth.tsx
@@ -1,12 +1,14 @@
 import { Link } from "react-router";
+import MarkdownTTS from "@/components/ui/markdown-tts";
 
 export default function youth(){
     return (
         <div className="max-w-6xl mx-auto px-6 py-5">
             <h4 className="text-accent text-right">For youth</h4>
             
-            <div>
+            <MarkdownTTS controlsClassName="flex flex-row-reverse items-start justify-between gap-4">
                 <h1 className="text-4xl font-black text-accent mb-6">Welcome to FORWARD!</h1>
+                <span className="text-[0px] opacity-0">.</span>
                 <p className="mb-6">We're glad you're here. This website is all about helping you get ready for what's next — whether that's going back to school, getting a job, or living more on your own.</p>
                 
                 <p className="mb-8">
@@ -19,82 +21,92 @@ export default function youth(){
                     alt="Young Adults chilling by a buildings curb" 
                     className="w-full max-w-2xl mx-auto rounded-lg my-6"
                 />
-            </div>
+            </MarkdownTTS>
 
             {/* paragraph two */}
             <div className="border-t border-muted pt-8">
-                <h3 className="text-2xl font-black mb-6">What is FORWARD?</h3>
+                <MarkdownTTS controlsClassName="flex flex-row-reverse items-start justify-between gap-4">
+                    <h3 className="text-2xl font-black mb-6">What is FORWARD?</h3>
+                    <span className="text-[0px] opacity-0">.</span>
 
-                <p className="mb-6">
-                    FORWARD is a web-based program made just for youth like you. It's designed to help you get ready for the big changes that can happen when leaving a program 
-                    or becoming an adult — things like going to school, getting a job, or living on your own.
-                </p>
+                    <p className="mb-6">
+                        FORWARD is a web-based program made just for youth like you. It's designed to help you get ready for the big changes that can happen when leaving a program 
+                        or becoming an adult — things like going to school, getting a job, or living on your own.
+                    </p>
 
-                <p className="mb-4">You'll work through fun, interactive lessons about real-life topics. The lessons are built with your needs in mind, including:</p>
+                    <p className="mb-4">You'll work through fun, interactive lessons about real-life topics. The lessons are built with your needs in mind, including:</p>
 
-                <div className="markdown mb-6">
-                    <ul>
-                        <li>Easy-to-read text</li>
-                        <li>Videos with captions</li>
-                        <li>Images with descriptions</li>
-                        <li>Tools to read text out loud</li>
-                        <li>Choices about how you want to learn</li>
-                    </ul>
-                </div>
-                
-                <p className="mb-6">
-                    You'll also get to decide what to learn first. Want to learn about money before college? Go for it. Curious about how to talk to a boss or teacher? 
-                    You can start there. You're in charge of your learning.
-                </p>
-                
-                <img 
-                    src="/about_page/happy_students.jpg" 
-                    alt="Young Adults huddled, staring down happy" 
-                    className="w-full max-w-2xl mx-auto rounded-lg my-6"
-                />
+                    <div className="markdown mb-6">
+                        <ul>
+                            <li>Easy-to-read text</li>
+                            <li>Videos with captions</li>
+                            <li>Images with descriptions</li>
+                            <li>Tools to read text out loud</li>
+                            <li>Choices about how you want to learn</li>
+                        </ul>
+                    </div>
+                    
+                    <p className="mb-6">
+                        You'll also get to decide what to learn first. Want to learn about money before college? Go for it. Curious about how to talk to a boss or teacher? 
+                        You can start there. You're in charge of your learning.
+                    </p>
+                    
+                    <img 
+                        src="/about_page/happy_students.jpg" 
+                        alt="Young Adults huddled, staring down happy" 
+                        className="w-full max-w-2xl mx-auto rounded-lg my-6"
+                    />
+                </MarkdownTTS>
             </div>
 
             {/* section 3 */}
             <div className="border-t border-muted pt-8 mt-8">
-                <h3 className="text-2xl font-black mb-6">What Will I Learn?</h3>
-                
-                <p className="mb-4">There are <strong>five lessons</strong> in FORWARD right now:</p>
+                <MarkdownTTS controlsClassName="flex flex-row-reverse items-start justify-between gap-4">
+                    <h3 className="text-2xl font-black mb-6">What Will I Learn?</h3>
+                    <span className="text-[0px] opacity-0">.</span>
+                    
+                    <p className="mb-4">There are <strong>five lessons</strong> in FORWARD right now:</p>
 
-                <div className="markdown mb-6">
-                    <ol>
-                        <li><strong>Going to College</strong> – Learn what it takes to apply and succeed in school after high school.</li>
-                        <li><strong>Communication & Disclosure</strong> – Improve your communication skills and learn how to talk about hard or complicated topics with different people.</li>
-                        <li><strong>Personal Finances</strong> – Learn about saving, spending, and other money related topics</li>
-                        <li><strong>Self-Advocacy</strong> – Build the skills to speak up for yourself and your future.</li>
-                        <li><strong>Soft Skills</strong> – Practice teamwork, problem solving, and showing up strong at school, work, or in your personal life.</li>
-                    </ol>
+                    <div className="markdown mb-6">
+                        <ol>
+                            <li><strong>Going to College</strong> – Learn what it takes to apply and succeed in school after high school.</li>
+                            <li><strong>Communication & Disclosure</strong> – Improve your communication skills and learn how to talk about hard or complicated topics with different people.</li>
+                            <li><strong>Personal Finances</strong> – Learn about saving, spending, and other money related topics</li>
+                            <li><strong>Self-Advocacy</strong> – Build the skills to speak up for yourself and your future.</li>
+                            <li><strong>Soft Skills</strong> – Practice teamwork, problem solving, and showing up strong at school, work, or in your personal life.</li>
+                        </ol>
+                    </div>
+
+                    <p className="mb-8">
+                        Each lesson has activities like quizzes, games, choose-your-own-path stories, matching, video examples, and more. 
+                        You'll get to explore topics your way and at your pace.
+                    </p>
+                    
+                    <img 
+                        src="/about_page/thumbs_up.jpg" 
+                        alt="People smiling giving a thumbs up" 
+                        className="w-full max-w-2xl mx-auto rounded-lg my-6"
+                    />
+                    </MarkdownTTS>
                 </div>
-
-                <p className="mb-8">
-                    Each lesson has activities like quizzes, games, choose-your-own-path stories, matching, video examples, and more. 
-                    You'll get to explore topics your way and at your pace.
-                </p>
-                
-                <img 
-                    src="/about_page/thumbs_up.jpg" 
-                    alt="People smiling giving a thumbs up" 
-                    className="w-full max-w-2xl mx-auto rounded-lg my-6"
-                />
-            </div>
+            
 
             <div className="mt-8">
-                <h3 className="text-2xl font-black mb-6">Why FORWARD?</h3>
-                
-                <p className="mb-8">
-                    We created FORWARD because we know you have big goals and a bright future. But we also know that transitions — like reentering your community, 
-                    finishing school, or getting your first job — can be tough. FORWARD is here to make things a little easier by giving you the tools, knowledge, 
-                    and support to reach your goals.
-                </p>
-                
-                <p className="mb-8">
-                    Everything on this site is made to work for different learning styles, reading levels, and support needs. Whether you have a disability, 
-                    are still figuring things out, or just want to be ready — FORWARD is for you.
-                </p>
+                <MarkdownTTS controlsClassName="flex flex-row-reverse items-start justify-between gap-4">
+                    <h3 className="text-2xl font-black mb-6">Why FORWARD?</h3>
+                     <span className="text-[0px] opacity-0">.</span>
+                    
+                    <p className="mb-8">
+                        We created FORWARD because we know you have big goals and a bright future. But we also know that transitions — like reentering your community, 
+                        finishing school, or getting your first job — can be tough. FORWARD is here to make things a little easier by giving you the tools, knowledge, 
+                        and support to reach your goals.
+                    </p>
+                    
+                    <p className="mb-8">
+                        Everything on this site is made to work for different learning styles, reading levels, and support needs. Whether you have a disability, 
+                        are still figuring things out, or just want to be ready — FORWARD is for you.
+                    </p>
+                </MarkdownTTS>
             </div>
 
             <div className="text-right mt-8">


### PR DESCRIPTION

https://github.com/user-attachments/assets/63f9c39d-8a1d-44b8-9825-4401d076d74b

Simple addition of the MarkdownTTS component to add audio to the about pages, Anne asked for it some time ago but there was other more high priority items we were working on.

Also switched Youth to be the first page that clicking Learn more redirects to, it has a more appropriate opening and introduction compared to supporters of youth.
