### PR TITLE
finish support for video quiz and questions

### DIFF
--- a/Forward-client/app/features/curriculum/components/question.tsx
+++ b/Forward-client/app/features/curriculum/components/question.tsx
@@ -73,6 +73,20 @@ export default function Question({
           </div>
         )}
 
+
+      {question.video && (
+        <div className="mb-6">
+          <video 
+            controls 
+            className="w-full max-w-lg mx-auto rounded-lg shadow-sm border border-muted object-cover"
+            style={{ maxHeight: '400px' }}
+          >
+            <source src={question.video} type="video/mp4" />
+            Your browser does not support the video tag.
+          </video>
+        </div>
+      )}
+
         {question.caption && (
           <p className="text-muted-foreground text-sm italic">
             {question.caption}

--- a/Forward-client/app/features/curriculum/components/quiz.tsx
+++ b/Forward-client/app/features/curriculum/components/quiz.tsx
@@ -147,6 +147,20 @@ export default function Quiz({ quiz }: { quiz: Quiz }) {
           />
         </div>
       )}
+
+      {/* Quiz level videos */}
+      {quiz.video && (
+        <div className="mb-6">
+          <video 
+            controls 
+            className="w-full max-w-lg mx-auto rounded-lg shadow-sm border border-muted object-cover"
+            style={{ maxHeight: '400px' }}
+          >
+            <source src={quiz.video} type="video/mp4" />
+            Your browser does not support the video tag.
+          </video>
+        </div>
+      )}
       
       
       {quiz.questions.map((question: QuestionType, questionNumber) => {

--- a/Forward-client/app/features/curriculum/types/index.ts
+++ b/Forward-client/app/features/curriculum/types/index.ts
@@ -119,6 +119,7 @@ export interface Quiz extends BaseActivity {
   };
   questions: Question[];
   image?: string;
+  video?: string;
 }
 
 export interface Question {
@@ -144,6 +145,7 @@ export interface Question {
     correct: string;
     incorrect: string;
   };
+  video?: string;
 }
 
 export interface Poll extends BaseActivity {

--- a/Forward-server/core/management/commands/seed_lessons_data.py
+++ b/Forward-server/core/management/commands/seed_lessons_data.py
@@ -186,7 +186,7 @@ class Command(BaseCommand):
                 if act_type in {"textcontent", "fillintheblank", "quiz"}
                 else None
             )
-            video_name = defaults.pop("video", None) if act_type == "video" else None
+            video_name = defaults.pop("video", None) if act_type in {"video", "quiz"} else None
             twine_name = defaults.pop("file", None) if act_type == "twine" else None
             cust_name = defaults.pop("document", None) if act_type == "customactivity" else None
 
@@ -247,7 +247,7 @@ class Command(BaseCommand):
                         rel_path=self.folder_path / image_name,
                         label=f"{ActivityModel.__name__} asset",
                     )
-                elif act_type == "video" and video_name:
+                elif act_type in {"video", "quiz"} and video_name:
                     self._save_model_file(
                         instance=activity,
                         field_name="video",
@@ -344,6 +344,7 @@ class Command(BaseCommand):
         for order, q in enumerate(questions, start=1):
             q = q.copy()
             question_image_name = q.pop("image", None)
+            question_video_name = q.pop("video", None)
 
             defaults = {
                 "question_text": q.get("question_text", ""),
@@ -365,6 +366,15 @@ class Command(BaseCommand):
                         field_name="image",
                         rel_path=self.folder_path / question_image_name,
                         label=f"Question image",
+                    )
+
+                # same thing but for video
+                if question_video_name:
+                    self._save_model_file(
+                        instance=obj,
+                        field_name="video",
+                        rel_path=self.folder_path / question_video_name,
+                        label=f"Question video"
                     )
                 self._log(
                     f"    {'Created' if created else 'Updated'} question "

--- a/Forward-server/core/migrations/0001_initial.py
+++ b/Forward-server/core/migrations/0001_initial.py
@@ -522,6 +522,7 @@ class Migration(migrations.Migration):
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('updated_at', models.DateTimeField(auto_now=True)),
                 ('image', models.ImageField(blank=True, help_text='Optional Image to accompany the Quiz', null=True, upload_to='public/quiz/')),
+                ('video', models.FileField(blank=True, help_text='Optional video to accompany the Quiz', null=True, upload_to='public/video', validators=[django.core.validators.FileExtensionValidator(allowed_extensions=['mp4'])])),
                 ('passing_score', models.PositiveIntegerField(default=80, help_text='Minimum score required to pass the quiz')),
                 ('lesson', models.ForeignKey(help_text='The lesson this activity belongs to', on_delete=django.db.models.deletion.CASCADE, related_name='%(class)s_activities', to='core.lesson')),
             ],
@@ -536,6 +537,7 @@ class Migration(migrations.Migration):
             name='Question',
             fields=[
                 ('image', models.ImageField(blank=True, help_text='Optional image to accompany the Question', null=True, upload_to='public/question/')),
+                ('video', models.FileField(blank=True, help_text='Optional video to accompany the Question', null=True, upload_to='public/question/', validators=[django.core.validators.FileExtensionValidator(allowed_extensions=['mp4'])])),
                 ('id', models.UUIDField(default=uuid.uuid4, editable=False, help_text='the uuid of the database item', primary_key=True, serialize=False)),
                 ('question_text', martor.models.MartorField(help_text='The text of the question')),
                 ('feedback_config', django_jsonform.models.fields.JSONField(default=dict, help_text='Feedback configuration for correct/incorrect responses')),

--- a/Forward-server/core/models.py
+++ b/Forward-server/core/models.py
@@ -489,23 +489,12 @@ class Quiz(BaseActivity):
 
     image = models.ImageField(upload_to='public/quiz/', null=True, blank=True, help_text="Optional Image to accompany the Quiz")
 
+    video = models.FileField(upload_to='public/video', null=True, blank=True, validators=[FileExtensionValidator(allowed_extensions=['mp4'])], help_text= "Optional video to accompany the Quiz")
+
     passing_score = models.PositiveIntegerField(
         help_text="Minimum score required to pass the quiz",
         default=80
     )
-
-    # feedback_config = JSONField(
-    #     schema={
-    #         "type": "object",
-    #         "properties": {
-    #             "correct": {"type": "string"},
-    #             "incorrect": {"type": "string"}
-    #         },
-    #         "required": ["correct", "incorrect"]
-    #     },
-    #     default=dict,
-    #     help_text="Configuration for correct/incorrect feedback"
-    # )
 
     class Meta(BaseActivity.Meta):
         verbose_name = "Quiz"
@@ -518,6 +507,7 @@ class Quiz(BaseActivity):
             # "feedback_config": self.feedback_config,
             "questions": [q.to_dict() for q in Question.objects.filter(quiz__id=self.id).order_by('order')],
             "image": self.image.url if self.image else None,
+            "video": self.video.url if self.video else None
         }
 
 
@@ -574,8 +564,9 @@ class Question(models.Model):
     ]
 
     image = models.ImageField(upload_to='public/question/', null=True, blank=True, help_text="Optional image to accompany the Question")
-
-    # User's ge`ne`rated uuid
+    video = models.FileField( upload_to='public/question/', null=True, blank=True, validators=[FileExtensionValidator(allowed_extensions=['mp4'])], help_text="Optional video to accompany the Question")
+    
+    # User's generated uuid
     id = models.UUIDField(
         primary_key=True,
         default=uuid.uuid4,
@@ -668,7 +659,8 @@ class Question(models.Model):
             "is_required": self.is_required,
             "order": self.order,
             "feedback_config": self.feedback_config,
-            "image": self.image.url if self.image else None
+            "image": self.image.url if self.image else None,
+            "video": self.video.url if self.video else None
         }
 
 class Poll(BaseActivity):


### PR DESCRIPTION

https://github.com/user-attachments/assets/656680ff-35e5-47f5-9cd1-afb606c1b22a

The videos play audio, my screenrecorder must have not captured it.

Added support for video in quiz and questions. Pretty straightforward, right now there is no check if there is a video or an image, it technically would work for both but I didn't configure the css to look nice in that case, don't even know how it would look like. I'll assume we are following a standard either a quiz or question has an image or video, but not both.