### PR TITLE
remove retake survey from dashboard for now

### DIFF
--- a/Forward-client/app/routes/protected/dashboard.tsx
+++ b/Forward-client/app/routes/protected/dashboard.tsx
@@ -255,7 +255,7 @@ export default function Dashboard({ loaderData }: Route.ComponentProps) {
                 )}
               </div>
             )}
-            {user?.consent && (
+            {/* {user?.consent && (
               <div className="text-secondary-foreground bg-foreground outline-foreground-border col-start-2 col-end-2 rounded-3xl p-4 outline-1">
                 <p className="mb-2 text-left font-medium">
                   FORWARD Readiness Survey
@@ -267,7 +267,7 @@ export default function Dashboard({ loaderData }: Route.ComponentProps) {
                   Re-Take
                 </Link>
               </div>
-            )}
+            )} */}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Comment out retake survey so students don't click on the old survey. The link is still accessible through the URL, but Annee said she really doubts students would just type that in so I didn't remove that.